### PR TITLE
[Feature] 파티 검색 관련 기능 구현

### DIFF
--- a/src/main/java/meltingpot/server/area/controller/AreaController.java
+++ b/src/main/java/meltingpot/server/area/controller/AreaController.java
@@ -1,0 +1,42 @@
+package meltingpot.server.area.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import meltingpot.server.area.dto.AreaResponse;
+import meltingpot.server.area.service.AreaService;
+import meltingpot.server.util.ResponseCode;
+import meltingpot.server.util.ResponseData;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/area")
+@RequiredArgsConstructor
+public class AreaController {
+    private final AreaService areaService;
+
+    @GetMapping("/")
+    @Operation(summary = "최상위 지역 조회", description = "최상위 지역을 조회합니다. 해당 API를 호출 후 하위 지역을 조회할 수 있습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK", description = "지역 조회 성공")
+    })
+    public ResponseEntity<ResponseData<List<AreaResponse>>> listArea() {
+        return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_SUCCESS, areaService.listArea(null));
+    }
+
+    @GetMapping("/{parentAreaId}")
+    @Operation(summary = "하위 지역 조회", description = "하위 지역을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK", description = "지역 조회 성공")
+    })
+    public ResponseEntity<ResponseData<List<AreaResponse>>> listChildArea(@PathVariable("parentAreaId") Integer parentAreaId) {
+        return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_SUCCESS, areaService.listArea(parentAreaId));
+    }
+}

--- a/src/main/java/meltingpot/server/area/dto/AreaResponse.java
+++ b/src/main/java/meltingpot/server/area/dto/AreaResponse.java
@@ -1,0 +1,15 @@
+package meltingpot.server.area.dto;
+
+import meltingpot.server.domain.entity.Area;
+
+public record AreaResponse(
+    int areaId,
+    String areaName
+) {
+    public static AreaResponse of(Area area) {
+        return new AreaResponse(
+            area.getId(),
+            area.getAreaName()
+        );
+    }
+}

--- a/src/main/java/meltingpot/server/area/service/AreaService.java
+++ b/src/main/java/meltingpot/server/area/service/AreaService.java
@@ -1,0 +1,33 @@
+package meltingpot.server.area.service;
+
+import lombok.RequiredArgsConstructor;
+import meltingpot.server.area.dto.AreaResponse;
+import meltingpot.server.domain.repository.AreaRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AreaService {
+    private static final Logger log = LoggerFactory.getLogger(AreaService.class);
+    private final AreaRepository areaRepository;
+
+    @Transactional
+    public List<AreaResponse> listArea(Integer parentAreaId) {
+        if (parentAreaId == null) {
+            return areaRepository.findAllByAreaParentIdNull().stream()
+                    .map(AreaResponse::of)
+                    .collect(Collectors.toList());
+        } else {
+            return areaRepository.findAllByAreaParentId(parentAreaId).stream()
+                    .map(AreaResponse::of)
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/meltingpot/server/domain/entity/Area.java
+++ b/src/main/java/meltingpot/server/domain/entity/Area.java
@@ -17,7 +17,7 @@ public class Area extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "area_parent_id")
     private Area areaParent;
 

--- a/src/main/java/meltingpot/server/domain/entity/Area.java
+++ b/src/main/java/meltingpot/server/domain/entity/Area.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import meltingpot.server.domain.entity.common.BaseEntity;
 
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -19,6 +21,9 @@ public class Area extends BaseEntity {
     @JoinColumn(name = "area_parent_id")
     private Area areaParent;
 
+    @OneToMany(mappedBy = "areaParent", fetch = FetchType.LAZY)
+    private List<Area> subAreas;
+
     @NotNull
-    private String area_name;
+    private String areaName;
 }

--- a/src/main/java/meltingpot/server/domain/entity/party/enums/PartyTemporalFilter.java
+++ b/src/main/java/meltingpot/server/domain/entity/party/enums/PartyTemporalFilter.java
@@ -1,0 +1,5 @@
+package meltingpot.server.domain.entity.party.enums;
+
+public enum PartyTemporalFilter {
+    RECENT_WEEK, RECENT_MONTH, ORDER_CREATED_AT_ASC, ORDER_CREATED_AT_DESC
+}

--- a/src/main/java/meltingpot/server/domain/repository/AreaRepository.java
+++ b/src/main/java/meltingpot/server/domain/repository/AreaRepository.java
@@ -1,0 +1,11 @@
+package meltingpot.server.domain.repository;
+
+import meltingpot.server.domain.entity.Area;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.ArrayList;
+
+public interface AreaRepository extends JpaRepository<Area, Integer> {
+    ArrayList<Area> findAllByAreaParentIdNull();
+    ArrayList<Area> findAllByAreaParentId(int parentAreaId);
+}

--- a/src/main/java/meltingpot/server/domain/repository/party/PartyRepository.java
+++ b/src/main/java/meltingpot/server/domain/repository/party/PartyRepository.java
@@ -2,7 +2,8 @@ package meltingpot.server.domain.repository.party;
 
 import meltingpot.server.domain.entity.party.Party;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface PartyRepository extends JpaRepository<Party, Integer> {
+public interface PartyRepository extends JpaRepository<Party, Integer>, JpaSpecificationExecutor<Party> {
     Party findByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/meltingpot/server/domain/specification/party/PartySpecification.java
+++ b/src/main/java/meltingpot/server/domain/specification/party/PartySpecification.java
@@ -1,0 +1,54 @@
+package meltingpot.server.domain.specification.party;
+
+import meltingpot.server.domain.entity.Area;
+import meltingpot.server.domain.entity.party.Party;
+import meltingpot.server.domain.entity.party.enums.PartyStatus;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PartySpecification {
+    static Specification<Party> containingSubject(String q) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("partySubject"), "%" + q + "%");
+    }
+
+    static Specification<Party> containingOwner(String q) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("account").get("name"), "%" + q + "%");
+    }
+
+    static Specification<Party> containingAddress(String q) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("partyLocationAddress"), "%" + q + "%");
+    }
+
+    static Specification<Party> inArea(List<Area> q) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.in(root.get("partyArea").in(q));
+    }
+
+    static Specification<Party> startInDay(Long q) {
+        return (root, query, criteriaBuilder) -> {
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime lessThan = now.plusDays(q);
+
+            return criteriaBuilder.between(root.get("partyStartTime"), now, lessThan);
+        };
+    }
+
+    static Specification<Party> orderByStartTimeAsc() {
+        return (root, query, criteriaBuilder) -> {
+            query.orderBy(criteriaBuilder.asc(root.get("partyStartTime")));
+            return null;
+        };
+    }
+
+    static Specification<Party> orderByStartTimeDesc() {
+        return (root, query, criteriaBuilder) -> {
+            query.orderBy(criteriaBuilder.desc(root.get("partyStartTime")));
+            return null;
+        };
+    }
+
+    static Specification<Party> isStatus(PartyStatus q) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("partyStatus"), q);
+    }
+}

--- a/src/main/java/meltingpot/server/party/controller/PartySearchController.java
+++ b/src/main/java/meltingpot/server/party/controller/PartySearchController.java
@@ -1,0 +1,40 @@
+package meltingpot.server.party.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import meltingpot.server.party.dto.PartyResponse;
+import meltingpot.server.party.dto.PartySearchRequest;
+import meltingpot.server.party.service.PartySearchService;
+import meltingpot.server.util.PageResponse;
+import meltingpot.server.util.ResponseCode;
+import meltingpot.server.util.ResponseData;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/v1/search")
+@RequiredArgsConstructor
+public class PartySearchController {
+    private final PartySearchService partySearchService;
+
+    @PostMapping("")
+    @Operation(summary = "파티 검색", description = "파티를 검색합니다. TemporalFilter(기간 필터)는 중복 선택이 가능하나, 1주일/한달, 오름차순/내림차순은 중복 선택이 불가능합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "OK", description = "파티 검색 성공"),
+        @ApiResponse(responseCode = "BAD_REQUEST", description = "파티 검색 실패")
+    })
+    public ResponseEntity<ResponseData<PageResponse<PartyResponse>>> searchParty(
+        @RequestBody @Valid PartySearchRequest partySearchRequest
+    ) {
+        try {
+            return ResponseData.toResponseEntity(ResponseCode.PARTY_SEARCH_SUCCESS, partySearchService.searchParty(partySearchRequest));
+        } catch (NoSuchElementException e) {
+            return ResponseData.toResponseEntity(ResponseCode.PARTY_SEARCH_FAIL, null);
+        }
+    }
+}

--- a/src/main/java/meltingpot/server/party/controller/PartySearchController.java
+++ b/src/main/java/meltingpot/server/party/controller/PartySearchController.java
@@ -35,6 +35,8 @@ public class PartySearchController {
             return ResponseData.toResponseEntity(ResponseCode.PARTY_SEARCH_SUCCESS, partySearchService.searchParty(partySearchRequest));
         } catch (NoSuchElementException e) {
             return ResponseData.toResponseEntity(ResponseCode.PARTY_SEARCH_FAIL, null);
+        } catch (IllegalArgumentException e) {
+            return ResponseData.toResponseEntity(ResponseCode.PARTY_INVALID_QUERY, null);
         }
     }
 }

--- a/src/main/java/meltingpot/server/party/dto/PartySearchRequest.java
+++ b/src/main/java/meltingpot/server/party/dto/PartySearchRequest.java
@@ -1,0 +1,30 @@
+package meltingpot.server.party.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PartySearchRequest(
+    Integer page,
+    String query,
+    Integer areaIdFilter,
+    List<String> temporalFilter,
+    String statusFilter
+) {
+    public static PartySearchRequest of(
+            Integer page,
+            String query,
+            Integer areaIdFilter,
+            List<String> temporalFilter,
+            String statusFilter
+    ) {
+        return new PartySearchRequest(
+            page,
+            query,
+            areaIdFilter,
+            temporalFilter,
+            statusFilter
+        );
+    }
+}

--- a/src/main/java/meltingpot/server/party/service/PartySearchService.java
+++ b/src/main/java/meltingpot/server/party/service/PartySearchService.java
@@ -1,0 +1,100 @@
+package meltingpot.server.party.service;
+
+import lombok.RequiredArgsConstructor;
+import meltingpot.server.domain.entity.Area;
+import meltingpot.server.domain.entity.party.Party;
+import meltingpot.server.domain.entity.party.enums.PartyStatus;
+import meltingpot.server.domain.entity.party.enums.PartyTemporalFilter;
+import meltingpot.server.domain.repository.AreaRepository;
+import meltingpot.server.domain.repository.party.PartyRepository;
+import meltingpot.server.domain.specification.party.PartySpecification;
+import meltingpot.server.party.dto.PartyResponse;
+import meltingpot.server.party.dto.PartySearchRequest;
+import meltingpot.server.util.PageResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PartySearchService {
+    private final PartyRepository partyRepository;
+    private final AreaRepository areaRepository;
+
+    @Transactional
+    public PageResponse<PartyResponse> searchParty(PartySearchRequest partySearchRequest) {
+        String query = partySearchRequest.query();
+        if (query.isEmpty()) {
+            query = "";
+        }
+
+        Specification<Party> spec = Specification.where(PartySpecification.containingAddress(query).or(PartySpecification.containingAddress(query).or(PartySpecification.containingAddress(query))));
+        Specification<Party> spec = Specification.where(PartySpecification.containingAddress(query).or(PartySpecification.containingSubject(query).or(PartySpecification.containingOwner(query))));
+
+        if (partySearchRequest.areaIdFilter() != null) {
+            ArrayList<Area> targetAreas = new ArrayList<>();
+            Area currentArea = areaRepository.findById(partySearchRequest.areaIdFilter()).orElseThrow();
+            while (currentArea != null) {
+                targetAreas.add(currentArea);
+                currentArea = currentArea.getAreaParent();
+            }
+
+            spec = spec.and(PartySpecification.inArea(targetAreas));
+        }
+
+        if (partySearchRequest.temporalFilter() != null) {
+            List<PartyTemporalFilter> partyTemporalFilter = new ArrayList<>();
+            for (String temporalFilter : partySearchRequest.temporalFilter()) {
+                partyTemporalFilter.add(PartyTemporalFilter.valueOf(temporalFilter));
+            }
+
+            if (partyTemporalFilter.contains(PartyTemporalFilter.RECENT_MONTH)) {
+                spec = spec.and(PartySpecification.startInDay(7L));
+            } else if (partyTemporalFilter.contains(PartyTemporalFilter.RECENT_WEEK)) {
+                spec = spec.and(PartySpecification.startInDay(1L));
+            }
+
+            if (partyTemporalFilter.contains(PartyTemporalFilter.ORDER_CREATED_AT_ASC)) {
+                spec = spec.and(PartySpecification.orderByStartTimeAsc());
+            } else {
+                spec = spec.and(PartySpecification.orderByStartTimeDesc());
+            }
+        } else {
+            spec = spec.and(PartySpecification.orderByStartTimeDesc());
+        }
+
+        if (partySearchRequest.statusFilter() != null) {
+            PartyStatus partyStatus = PartyStatus.valueOf(partySearchRequest.statusFilter());
+
+            if (partyStatus.equals(PartyStatus.RECRUIT_CLOSED)) {
+                spec = spec.and(PartySpecification.isStatus(PartyStatus.RECRUIT_CLOSED));
+            } else if (partyStatus.equals(PartyStatus.RECRUIT_SCHEDULED)) {
+                spec = spec.and(PartySpecification.isStatus(PartyStatus.RECRUIT_SCHEDULED));
+            } else {
+                spec = spec.and(PartySpecification.isStatus(PartyStatus.RECRUIT_OPEN));
+            }
+        } else {
+            spec = spec.and(PartySpecification.isStatus(PartyStatus.RECRUIT_OPEN));
+        }
+
+        // 전체 개수 카운트
+        int totalCount = (int) partyRepository.count(spec);
+
+        // 페이징 처리
+        int page = 1;
+        int itemsPerPage = 30;
+        if (partySearchRequest.page() != null) {
+            page = partySearchRequest.page();
+        }
+
+        int totalPage = (int) Math.ceil((double) totalCount / itemsPerPage);
+
+        List<PartyResponse> partyResponses = partyRepository.findAll(spec, PageRequest.of(page - 1, itemsPerPage)).stream().map(PartyResponse::of).toList();
+        return new PageResponse<>(partyResponses, page, itemsPerPage, totalPage, totalCount);
+    }
+}

--- a/src/main/java/meltingpot/server/party/service/PartySearchService.java
+++ b/src/main/java/meltingpot/server/party/service/PartySearchService.java
@@ -33,7 +33,10 @@ public class PartySearchService {
             query = "";
         }
 
-        Specification<Party> spec = Specification.where(PartySpecification.containingAddress(query).or(PartySpecification.containingAddress(query).or(PartySpecification.containingAddress(query))));
+        if (query.length() < 2 || query.length() > 30) {
+            throw new IllegalArgumentException("검색어는 2자 이상 30자 이하로 입력해주세요.");
+        }
+
         Specification<Party> spec = Specification.where(PartySpecification.containingAddress(query).or(PartySpecification.containingSubject(query).or(PartySpecification.containingOwner(query))));
 
         if (partySearchRequest.areaIdFilter() != null) {

--- a/src/main/java/meltingpot/server/util/ResponseCode.java
+++ b/src/main/java/meltingpot/server/util/ResponseCode.java
@@ -15,6 +15,7 @@ public enum ResponseCode {
     REISSUE_TOKEN_SUCCESS(OK, "토큰 재발급 성공"),
     PARTY_FETCH_SUCCESS(OK, "파티 정보 불러오기 성공"),
     PARTY_JOIN_SUCCESS(OK, "파티 참여 성공"),
+    AREA_FETCH_SUCCESS(OK, "지역 조회 성공"),
 
 
     /* 201 CREATED : 요청 성공, 자원 생성 */

--- a/src/main/java/meltingpot/server/util/ResponseCode.java
+++ b/src/main/java/meltingpot/server/util/ResponseCode.java
@@ -36,6 +36,7 @@ public enum ResponseCode {
     PARTY_REPORT_SELF(BAD_REQUEST, "본인이 작성한 파티는 신고할 수 없습니다"),
     PARTY_REPORT_ALREADY(BAD_REQUEST, "이미 신고한 파티입니다"),
     PARTY_SEARCH_FAIL(BAD_REQUEST, "파티 검색 실패"),
+    PARTY_INVALID_QUERY(BAD_REQUEST, "검색어는 2글자 이상 30글자 이하로 입력해주세요"),
 
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */

--- a/src/main/java/meltingpot/server/util/ResponseCode.java
+++ b/src/main/java/meltingpot/server/util/ResponseCode.java
@@ -14,6 +14,7 @@ public enum ResponseCode {
     SIGNOUT_SUCCESS(OK, "로그아웃 성공"),
     REISSUE_TOKEN_SUCCESS(OK, "토큰 재발급 성공"),
     PARTY_FETCH_SUCCESS(OK, "파티 정보 불러오기 성공"),
+    PARTY_SEARCH_SUCCESS(OK, "파티 검색 성공"),
     PARTY_JOIN_SUCCESS(OK, "파티 참여 성공"),
     AREA_FETCH_SUCCESS(OK, "지역 조회 성공"),
 
@@ -34,6 +35,7 @@ public enum ResponseCode {
     PARTY_ALREADY_JOINED(BAD_REQUEST, "이미 참여한 파티입니다"),
     PARTY_REPORT_SELF(BAD_REQUEST, "본인이 작성한 파티는 신고할 수 없습니다"),
     PARTY_REPORT_ALREADY(BAD_REQUEST, "이미 신고한 파티입니다"),
+    PARTY_SEARCH_FAIL(BAD_REQUEST, "파티 검색 실패"),
 
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */


### PR DESCRIPTION
## 요약
홈에서의 파티 검색 관련 기능을 구현한다.

<br><br>

## 작업 내용
- [x] 파티 검색 (개최된 파티 중 제목, 작성자, 위치에 검색어가 포함된 경우 노출, 검색어 30글자 제한)
- [x] 파티 상세 검색 (지역, 기간, 모집상태로 필터)
- 지역 : 시군구 - 상세지역
- 기간 : 최근 일주일 내 / 최근 한달 내 / 최신순 / 오래된 순
- 모집상태 : 모집중 / 모집예정 / 마감
- [x] 지역코드 조회
- [x] 지역코드 추가

<br><br>

## 참고 사항
파티 유형에 따른 충분한 테스트가 이루어지지 않았으므로,
이후 많은 개수의 파티 생성 후 추가 테스트가 요구된다.

<br><br>
