### PR TITLE
[Feature] 내 주변 파티 조회 기능 구현

### DIFF
--- a/src/main/java/meltingpot/server/party/controller/PartySearchController.java
+++ b/src/main/java/meltingpot/server/party/controller/PartySearchController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import meltingpot.server.party.dto.PartyNearbySearchRequest;
 import meltingpot.server.party.dto.PartyResponse;
 import meltingpot.server.party.dto.PartySearchRequest;
 import meltingpot.server.party.service.PartySearchService;
@@ -33,6 +34,24 @@ public class PartySearchController {
     ) {
         try {
             return ResponseData.toResponseEntity(ResponseCode.PARTY_SEARCH_SUCCESS, partySearchService.searchParty(partySearchRequest));
+        } catch (NoSuchElementException e) {
+            return ResponseData.toResponseEntity(ResponseCode.PARTY_SEARCH_FAIL, null);
+        } catch (IllegalArgumentException e) {
+            return ResponseData.toResponseEntity(ResponseCode.PARTY_INVALID_QUERY, null);
+        }
+    }
+
+    @PostMapping("/nearby")
+    @Operation(summary = "내 주변 파티 검색", description = "사용자의 위치를 기반으로 주변 파티를 검색합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "OK", description = "내 주변 파티 검색 성공"),
+        @ApiResponse(responseCode = "BAD_REQUEST", description = "내 주변 파티 검색 실패")
+    })
+    public ResponseEntity<ResponseData<PageResponse<PartyResponse>>> searchNearbyParty(
+        @RequestBody @Valid PartyNearbySearchRequest partyNearbySearchRequest
+    ) {
+        try {
+            return ResponseData.toResponseEntity(ResponseCode.PARTY_SEARCH_SUCCESS, partySearchService.searchNearbyParty(partyNearbySearchRequest));
         } catch (NoSuchElementException e) {
             return ResponseData.toResponseEntity(ResponseCode.PARTY_SEARCH_FAIL, null);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/meltingpot/server/party/dto/PartyNearbySearchRequest.java
+++ b/src/main/java/meltingpot/server/party/dto/PartyNearbySearchRequest.java
@@ -1,0 +1,21 @@
+package meltingpot.server.party.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PartyNearbySearchRequest(
+    Integer page,
+    Integer areaId
+) {
+    public static PartyNearbySearchRequest of(
+            Integer page,
+            Integer areaId
+    ) {
+        return new PartyNearbySearchRequest(
+            page,
+            areaId
+        );
+    }
+}


### PR DESCRIPTION
## 요약
내 주변의 파티를 조회할 수 있는 기능을 구현한다.

<br><br>

## 작업 내용
- [x] ~~현재 위치 설정 API~~
- [x] 주변 파티 조회 API

<br><br>

## 참고 사항
~~주변 파티 조회 API 호출 시 현재 위치를 파라미터로 넣을 수 있으나,~~
~~해당 값은 optional이며 입력된 경우 파라미터의 현재 위치를, 입력되지 않은 경우 현재 위치 설정 API를 통해 설정된 위치를 사용한다.~~

~~두 위치 모두 설정되지 않았을 경우 임의의 default coordinate를 사용하여 지정한다.~~
현재 위치를 항상 파라미터로 제공받는다. 만약 제공받지 못한 경우 ID 1 (서울특별시)를 기준으로 조회한다.

<br><br>
