### PR TITLE
[Feat] 좌표를 통해 지역 코드를 반환하는 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,11 @@ dependencies {
 	implementation 'software.amazon.ion:ion-java:1.0.3'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	if (isAppleSilicon()) {
+		runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.94.Final:osx-aarch_64")
+	}
+
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -57,4 +62,8 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+static boolean isAppleSilicon() {
+	System.getProperty("os.name") == "Mac OS X" && System.getProperty("os.arch") == "aarch64"
 }

--- a/src/main/java/meltingpot/server/area/controller/AreaController.java
+++ b/src/main/java/meltingpot/server/area/controller/AreaController.java
@@ -40,6 +40,15 @@ public class AreaController {
         return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_SUCCESS, areaService.listArea(parentAreaId));
     }
 
+    @GetMapping("/{areaId}/parent")
+    @Operation(summary = "상위 지역 조회", description = "상위 지역을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK", description = "지역 조회 성공")
+    })
+    public ResponseEntity<ResponseData<List<AreaResponse>>> listParentAreas(@PathVariable("areaId") Integer areaId) {
+        return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_SUCCESS, areaService.listParentAreas(areaId));
+    }
+
     @GetMapping("/search-by-coord")
     @Operation(summary = "좌표로 지역 조회", description = "좌표로 지역을 조회합니다.")
     @ApiResponses(value = {

--- a/src/main/java/meltingpot/server/area/controller/AreaController.java
+++ b/src/main/java/meltingpot/server/area/controller/AreaController.java
@@ -39,4 +39,26 @@ public class AreaController {
     public ResponseEntity<ResponseData<List<AreaResponse>>> listChildArea(@PathVariable("parentAreaId") Integer parentAreaId) {
         return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_SUCCESS, areaService.listArea(parentAreaId));
     }
+
+    @GetMapping("/search-by-coord")
+    @Operation(summary = "좌표로 지역 조회", description = "좌표로 지역을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "OK", description = "지역 조회 성공")
+    })
+    public ResponseEntity<ResponseData<AreaResponse>> getAreaByCoordinate(Double latitude, Double longitude) {
+        try {
+            return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_SUCCESS, areaService.getAreaByCoordinate(latitude, longitude));
+        } catch (Exception e) {
+            if (e.getMessage().equals("해당 좌표는 한국 내에 존재하지 않습니다.")) {
+                return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_FAILED_NOT_SERVICE_AREA, null);
+            } else if (e.getMessage().equals("해당 좌표와 일치하는 결과를 찾을 수 없었습니다.")) {
+                return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_FAILED_NOT_IN_OUR_DB, null);
+            } else if (e.getMessage().equals("법정동 정보가 없는 좌표입니다.")) {
+                return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_FAILED_NO_BDONG_INFO, null);
+            } else if (e.getMessage().equals("해당 지역 정보가 없습니다.")) {
+                return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_FAILED_NOT_IN_OUR_DB, null);
+            }
+            return ResponseData.toResponseEntity(ResponseCode.AREA_FETCH_FAILED, null);
+        }
+    }
 }

--- a/src/main/java/meltingpot/server/area/dto/KakaoGeocodingDocumentResponse.java
+++ b/src/main/java/meltingpot/server/area/dto/KakaoGeocodingDocumentResponse.java
@@ -1,0 +1,15 @@
+package meltingpot.server.area.dto;
+
+public record KakaoGeocodingDocumentResponse(
+        String region_type,
+        String address_name,
+        String region_1depth_name,
+        String region_2depth_name,
+        String region_3depth_name,
+        String region_4depth_name,
+        String code,
+        Double x,
+        Double y
+) {
+
+}

--- a/src/main/java/meltingpot/server/area/dto/KakaoMetaResponse.java
+++ b/src/main/java/meltingpot/server/area/dto/KakaoMetaResponse.java
@@ -1,0 +1,6 @@
+package meltingpot.server.area.dto;
+
+public record KakaoMetaResponse(
+        Integer total_count
+) {
+}

--- a/src/main/java/meltingpot/server/area/dto/KakaoResponse.java
+++ b/src/main/java/meltingpot/server/area/dto/KakaoResponse.java
@@ -1,0 +1,9 @@
+package meltingpot.server.area.dto;
+
+import java.util.List;
+
+public record KakaoResponse(
+        KakaoMetaResponse meta,
+        List<KakaoGeocodingDocumentResponse> documents
+) {
+}

--- a/src/main/java/meltingpot/server/area/service/AreaService.java
+++ b/src/main/java/meltingpot/server/area/service/AreaService.java
@@ -2,12 +2,18 @@ package meltingpot.server.area.service;
 
 import lombok.RequiredArgsConstructor;
 import meltingpot.server.area.dto.AreaResponse;
+import meltingpot.server.area.dto.KakaoGeocodingDocumentResponse;
+import meltingpot.server.area.dto.KakaoResponse;
+import meltingpot.server.domain.entity.Area;
 import meltingpot.server.domain.repository.AreaRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,6 +23,9 @@ import java.util.stream.Collectors;
 public class AreaService {
     private static final Logger log = LoggerFactory.getLogger(AreaService.class);
     private final AreaRepository areaRepository;
+
+    @Value("${cloud.kakao.rest_key}")
+    private String kakaoRestKey;
 
     @Transactional
     public List<AreaResponse> listArea(Integer parentAreaId) {
@@ -29,5 +38,64 @@ public class AreaService {
                     .map(AreaResponse::of)
                     .collect(Collectors.toList());
         }
+    }
+
+    @Transactional
+    public AreaResponse getAreaByCoordinate(Double latitude, Double longitude) {
+        // 대략적인 국내 여부를 확인 (추후 다각형으로 전환 필요)
+        if (latitude < 33.1 || latitude > 38.45 || longitude < 125.06 || longitude > 131.87) {
+            throw new IllegalArgumentException("해당 좌표는 한국 내에 존재하지 않습니다.");
+        }
+
+        WebClient webClient = WebClient.builder().build();
+
+        KakaoResponse response = webClient
+                .get()
+                .uri(String.format("https://dapi.kakao.com/v2/local/geo/coord2regioncode.json?x=%s&y=%s", longitude, latitude))
+                .header("Authorization", String.format("KakaoAK %s", kakaoRestKey))
+                .retrieve()
+                .bodyToMono(KakaoResponse.class)
+                .block();
+
+        if (response == null || response.meta().total_count() == 0) {
+            throw new IllegalArgumentException("해당 좌표와 일치하는 결과를 찾을 수 없었습니다.");
+        }
+
+        // 우리 시스템은 법정동 기반으로 운영된다
+        KakaoGeocodingDocumentResponse bArea = response.documents().stream()
+                .filter(document -> document.region_type().equals("B"))
+                .findFirst()
+                .orElse(null);
+
+        if (bArea == null) {
+            throw new IllegalArgumentException("법정동 정보가 없는 좌표입니다.");
+        }
+
+        List<String> areaNames = Arrays.asList(bArea.region_1depth_name(), bArea.region_2depth_name(), bArea.region_3depth_name(), bArea.region_4depth_name());
+        Area lastArea = null;
+        for (String areaName: areaNames) {
+            if (areaName.isEmpty()) {
+                continue;
+            }
+
+            Area area;
+            if (lastArea == null) {
+                area = areaRepository.findAreaByAreaParentIdIsNullAndAreaName(areaName);
+            } else {
+                area = areaRepository.findAreaByAreaParentIdAndAreaName(lastArea.getId(), areaName);
+            }
+
+            if (area == null) {
+                // 만약 정보가 없는 경우 상위 지역을 반환한다
+                continue;
+            }
+            lastArea = area;
+        }
+
+        if (lastArea == null) {
+            throw new IllegalArgumentException("해당 지역 정보가 없습니다.");
+        }
+
+        return AreaResponse.of(lastArea);
     }
 }

--- a/src/main/java/meltingpot/server/area/service/AreaService.java
+++ b/src/main/java/meltingpot/server/area/service/AreaService.java
@@ -6,13 +6,12 @@ import meltingpot.server.area.dto.KakaoGeocodingDocumentResponse;
 import meltingpot.server.area.dto.KakaoResponse;
 import meltingpot.server.domain.entity.Area;
 import meltingpot.server.domain.repository.AreaRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,7 +20,6 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AreaService {
-    private static final Logger log = LoggerFactory.getLogger(AreaService.class);
     private final AreaRepository areaRepository;
 
     @Value("${cloud.kakao.rest_key}")
@@ -38,6 +36,19 @@ public class AreaService {
                     .map(AreaResponse::of)
                     .collect(Collectors.toList());
         }
+    }
+
+    @Transactional
+    public List<AreaResponse> listParentAreas(Integer areaId) {
+        Area area = areaRepository.findById(areaId).orElseThrow(() -> new IllegalArgumentException("해당 지역 정보가 없습니다."));
+        List<AreaResponse> parentAreas = new ArrayList<>();
+
+        parentAreas.add(AreaResponse.of(area));
+        while (area.getAreaParent() != null) {
+            area = areaRepository.findById(area.getAreaParent().getId()).orElseThrow(() -> new IllegalArgumentException("해당 지역 정보가 없습니다."));
+            parentAreas.add(AreaResponse.of(area));
+        }
+        return parentAreas;
     }
 
     @Transactional

--- a/src/main/java/meltingpot/server/domain/repository/AreaRepository.java
+++ b/src/main/java/meltingpot/server/domain/repository/AreaRepository.java
@@ -8,4 +8,7 @@ import java.util.ArrayList;
 public interface AreaRepository extends JpaRepository<Area, Integer> {
     ArrayList<Area> findAllByAreaParentIdNull();
     ArrayList<Area> findAllByAreaParentId(int parentAreaId);
+
+    Area findAreaByAreaParentIdIsNullAndAreaName(String areaName);
+    Area findAreaByAreaParentIdAndAreaName(int parentAreaId, String areaName);
 }

--- a/src/main/java/meltingpot/server/util/ResponseCode.java
+++ b/src/main/java/meltingpot/server/util/ResponseCode.java
@@ -51,7 +51,10 @@ public enum ResponseCode {
     PARTY_REPORT_ALREADY(BAD_REQUEST, "이미 신고한 파티입니다"),
     PARTY_SEARCH_FAIL(BAD_REQUEST, "파티 검색 실패"),
     PARTY_INVALID_QUERY(BAD_REQUEST, "검색어는 2글자 이상 30글자 이하로 입력해주세요"),
-
+    AREA_FETCH_FAILED(BAD_REQUEST, "지역 조회 실패"),
+    AREA_FETCH_FAILED_NOT_SERVICE_AREA(BAD_REQUEST, "현재 좌표 조회는 국내에서만 사용 가능합니다"),
+    AREA_FETCH_FAILED_NOT_IN_OUR_DB(BAD_REQUEST, "해당 좌표는 등록되지 않은 좌표입니다"),
+    AREA_FETCH_FAILED_NO_BDONG_INFO(BAD_REQUEST, "해당 좌표는 법정동 정보가 없습니다"),
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
     INVALID_AUTH_TOKEN(UNAUTHORIZED, "권한 정보가 없는 토큰입니다"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,8 @@ jwt:
   token-validity-in-seconds: 1209600 # 테스트용 14일 유효기간
 
 cloud:
+  kakao:
+    rest_key: ${KAKAO_REST_KEY}
   r2:
     url: ${R2_URL}
     accessKey: ${R2_ACCESS_KEY}


### PR DESCRIPTION
## 요약
좌표를 통해 지역 코드를 반환하는 API를 추가한다.

<br><br>

## 작업 내용
- [x] 좌표를 통해 지역 코드를 반환하는 API 추가
- [x] 하위 지역 좌표가 주어졌을 때 상위 지역 path를 반환하는 API 추가

<br><br>

## 참고 사항
Reverse Geocoding을 사용하여 작업을 진행하며, 단순 지역명 비교로 작동하기 때문에 검색되지 않을 수 있는 지역이 있을 수 있다.
추후 지역코드 정보에 좌표(geojson)을 추가하는 방법을 고려할 필요가 있다.